### PR TITLE
Provisional fix #33 (end-of-burn-spin)

### DIFF
--- a/scripts/lib_burn.ks
+++ b/scripts/lib_burn.ks
@@ -1,7 +1,6 @@
 @LAZYGLOBAL OFF.
 
-
-pOut("lib_burn.ks v1.1.1 20160802").
+pOut("lib_burn.ks v1.1.2 20160811").
 
 FOR f IN LIST(
   "lib_dv.ks",
@@ -81,10 +80,10 @@ FUNCTION burnNode
 
   LOCAL done IS BURN_NODE_IS_SMALL.
   IF done { burnSmallNode(n, bt). }
+  LOCAL follow_node IS TRUE.
 
   UNTIL done OR NOT ok {
     LOCAL acc IS SHIP:AVAILABLETHRUST / MASS.
-    LOCAL follow_node IS TRUE.
     IF acc > 0 {
       SET bt TO n:DELTAV:MAG / acc.
       SET BURN_THROTTLE TO burnThrottle(bt).


### PR DESCRIPTION
Follow_node was being reset to TRUE each loop, so the "original node" vector was continually being set to the current node vector, which in turn would encourage the craft to keep following it around and prevent the loop from ending (which is based on the original node and current node vectors diverging).

Needs testing, but I think this should fix #33 