### PR TITLE
Refactor steering, fix #29

### DIFF
--- a/scripts/lib_burn.ks
+++ b/scripts/lib_burn.ks
@@ -1,6 +1,6 @@
 @LAZYGLOBAL OFF.
 
-pOut("lib_burn.ks v1.1.2 20160811").
+pOut("lib_burn.ks v1.2.0 20160812").
 
 FOR f IN LIST(
   "lib_dv.ks",
@@ -23,18 +23,11 @@ FUNCTION changeBURN_WARP_BUFF
   IF wb > 0 { SET BURN_WARP_BUFF TO wb. }
 }
 
-FUNCTION steerNode
-{
-  PARAMETER n.
-  LOCK STEERING TO LOOKDIRUP(n:DELTAV, FACING:TOPVECTOR).
-  steerOn().
-}
-
 FUNCTION pointNode
 {
   PARAMETER n.
-  IF BURN_NODE_IS_SMALL { steerTo(n:DELTAV, FACING:TOPVECTOR). }
-  ELSE { steerNode(n). }
+  IF BURN_NODE_IS_SMALL { LOCAL n_v IS n:DELTAV. steerTo({ RETURN n_v. }). }
+  ELSE { steerTo({ RETURN n:DELTAV. }). }
   pOut("Aligning with node.").
   WAIT UNTIL steerOk(0.4).
 }
@@ -93,7 +86,7 @@ FUNCTION burnNode
         SET done TO TRUE.
       } ELSE IF follow_node AND n:DELTAV:MAG < BURN_SMALL_DV {
         SET o_dv TO n:DELTAV.
-        steerTo(o_dv, FACING:TOPVECTOR).
+        steerTo({ RETURN o_dv. }).
         SET follow_node TO FALSE.
       }
     } ELSE {

--- a/scripts/lib_dock.ks
+++ b/scripts/lib_dock.ks
@@ -1,7 +1,6 @@
 @LAZYGLOBAL OFF.
 
-
-pOut("lib_dock.ks v1.0 20160714").
+pOut("lib_dock.ks v1.1.0 20160812").
 
 FOR f IN LIST(
   "lib_rcs.ks",
@@ -42,12 +41,6 @@ FUNCTION clearPorts
   UNLOCK S_NODE.
   UNLOCK T_FACE.
   UNLOCK T_NODE.
-}
-
-FUNCTION steerToPort
-{
-  LOCK STEERING TO LOOKDIRUP(-T_FACE,FACING:TOPVECTOR).
-  steerOn().
 }
 
 FUNCTION readyPorts
@@ -246,7 +239,7 @@ FUNCTION doDocking
   IF ok { SET ok TO plotDockingRoute(s_port,t_port). }
 
   IF ok {
-    steerToPort().
+    steerTo({ RETURN -T_FACE. }).
     WAIT UNTIL steerOk().
     enableRCS().
     SET ok TO followDockingRoute(s_port,t_port).

--- a/scripts/lib_lander_ascent.ks
+++ b/scripts/lib_lander_ascent.ks
@@ -1,7 +1,6 @@
 @LAZYGLOBAL OFF.
 
-
-pOut("lib_lander_ascent.ks v1.0.1 20160714").
+pOut("lib_lander_ascent.ks v1.1.0 20160812").
 
 FOR f IN LIST(
   "lib_steer.ks",
@@ -27,8 +26,7 @@ FUNCTION stopAscentValues
 
 FUNCTION steerAscent
 {
-  steerOn().
-  LOCK STEERING TO LOOKDIRUP(HEADING(LND_LAZ,landerPitch()):VECTOR,FACING:TOPVECTOR).
+  steerTo({ RETURN HEADING(LND_LAZ,landerPitch()):VECTOR. }).
 }
 
 FUNCTION ascentCirc
@@ -68,7 +66,7 @@ UNTIL rm = exit_mode
 {
   IF rm = 301 {
     SET WARP TO 0.
-    steerTo(UP:VECTOR,FACING:TOPVECTOR).
+    steerTo({ RETURN UP:VECTOR. }).
     hudMsg("Prepare for launch...").
     runMode(304,302).
   } ELSE IF rm = 302 {

--- a/scripts/lib_lander_descent.ks
+++ b/scripts/lib_lander_descent.ks
@@ -1,7 +1,6 @@
 @LAZYGLOBAL OFF.
 
-
-pOut("lib_lander_descent.ks v1.0.2 20160728").
+pOut("lib_lander_descent.ks v1.1.0 20160812").
 
 FOR f IN LIST(
   "lib_steer.ks",
@@ -128,11 +127,10 @@ FUNCTION warpToPeriapsis
   }
 }
 
-FUNCTION steerConstantAltitude
+FUNCTION constantAltitudeVec
 {
-  steerOn().
-  LOCK STEERING TO LOOKDIRUP(ANGLEAXIS(landerPitch(),VCRS(VELOCITY:SURFACE,BODY:POSITION))
-                 * VXCL(UP:VECTOR,-VELOCITY:SURFACE),FACING:TOPVECTOR).
+  RETURN ANGLEAXIS(landerPitch(),VCRS(VELOCITY:SURFACE,BODY:POSITION)) 
+         * VXCL(UP:VECTOR,-VELOCITY:SURFACE).
 }
 
 FUNCTION doConstantAltitudeBurn
@@ -256,7 +254,7 @@ FUNCTION doSetDown
   UNTIL adjustedAltitude() < 1 {
     IF adjustedAltitude() < 12 AND aim_speed > 2 {
       SET aim_speed TO 2.
-      steerTo(UP:VECTOR,FACING:TOPVECTOR).
+      steerTo({ RETURN UP:VECTOR. }).
     }
 
     LOCAL des_acc IS -SHIP:VERTICALSPEED - aim_speed.
@@ -328,7 +326,7 @@ UNTIL rm = exit_mode
     warpToPeriapsis(pe_safety_factor).
     runMode(232).
   } ELSE IF rm = 232 {
-    steerConstantAltitude().
+    steerTo(constantAltitudeVec@).
     doConstantAltitudeBurn(pe_safety_factor).
     runMode(233).
   } ELSE IF rm = 233 {

--- a/scripts/lib_launch_common.ks
+++ b/scripts/lib_launch_common.ks
@@ -1,6 +1,6 @@
 @LAZYGLOBAL OFF.
 
-pOut("lib_launch_common.ks v1.0.5 20160728").
+pOut("lib_launch_common.ks v1.1.0 20160812").
 
 FOR f IN LIST(
   "lib_burn.ks",
@@ -152,6 +152,5 @@ FUNCTION launchPitch
 
 FUNCTION steerLaunch
 {
-  steerOn().
-  LOCK STEERING TO LOOKDIRUP(HEADING(LCH_HEADING,LCH_PITCH):VECTOR,FACING:TOPVECTOR).
+  steerTo({ RETURN HEADING(LCH_HEADING,LCH_PITCH):VECTOR. }).
 }

--- a/scripts/lib_steer.ks
+++ b/scripts/lib_steer.ks
@@ -1,6 +1,7 @@
 @LAZYGLOBAL OFF.
 
-pOut("lib_steer.ks v1.2.0 20160812").
+
+pOut("lib_steer.ks v1.2.1 20160821").
 
 setTime("STEER").
 GLOBAL STEER_ON IS FALSE.
@@ -58,9 +59,8 @@ FUNCTION steerOk
 
   IF VANG(STEERINGMANAGER:TARGET:VECTOR,FACING:FOREVECTOR) < aoa AND 
      SHIP:ANGULARVEL:MAG < ((10 / precision) * 2 * CONSTANT:PI / SHIP:ORBIT:PERIOD) {
-      pOut("Steering aligned.").
-      RETURN TRUE.
-    }
+    pOut("Steering aligned.").
+    RETURN TRUE.
   }
   IF diffTime("STEER") > timeout_secs {
     pOut("Steering alignment timed out.").

--- a/scripts/lib_steer.ks
+++ b/scripts/lib_steer.ks
@@ -53,7 +53,7 @@ FUNCTION steerSun
 FUNCTION steerOk
 {
   PARAMETER aoa IS 1, precision IS 4, timeout_secs IS 60.
-  IF diffTime("STEER") { RETURN FALSE. }
+  IF diffTime("STEER") <= 0.1 { RETURN FALSE. }
   IF NOT STEERINGMANAGER:ENABLED { hudMsg("ERROR: Steering Manager not enabled!"). }
 
   IF VANG(STEERINGMANAGER:TARGET:VECTOR,FACING:FOREVECTOR) < aoa AND 


### PR DESCRIPTION
Fixes #29 
Replaces all the steerTo(vector, vector) calls with steerTo(function, function). All bar one "LOCK STEERING TO xxx" has been replaced with steerTo().

I've not updated lib_rendezvous as the close approach code that calls lock steering is going to get refactored.