### PR TITLE
Time refactor 35

### DIFF
--- a/scripts/lib_rendezvous.ks
+++ b/scripts/lib_rendezvous.ks
@@ -370,9 +370,7 @@ FUNCTION recalcCA
   PARAMETER t.
   LOCAL ca_details IS findTargetCA(t,TIMES[RDZ_CA]).
   setTime(RDZ_CA,ca_details[1]).
-  pOut("Closest approach: " + ROUND(ca_details[0]) + "m in " + ROUND(ca_details[1]-TIME:SECONDS) + 
-
-"s.").
+  pOut("Closest approach: " + ROUND(ca_details[0]) + "m in " + ROUND(ca_details[1]-TIME:SECONDS) + "s.").
   storeRdzDetails().
 }
 


### PR DESCRIPTION
Fix #37 - lib_rendezvous, use doWarp() instead of WARPTO()

I've also tightened up the time at which we'll drop out of time warp, so we'll be closer to the target.
