### PR TITLE
Transfer changes - in progress

### DIFF
--- a/documentation/lib_transfer_readme.md
+++ b/documentation/lib_transfer_readme.md
@@ -24,19 +24,21 @@ The initial value is the current `BODY` when the library is run.
 
 #### `MAX_SCORE`
 
-This is a large value, used by the node scoring functions as an initial value.
+This is a large value, used by the node scoring functions as an initial value. Due to the availability of "bonus" points, it's possible for a manoeuvre node to score higher than this value.
 
 The initial value is `99999`.
 
 #### `MIN_SCORE`
 
-This is a large, negative value, used by the node scoring functions when the solution is as bad as possible.
+This is a large, negative value, used by the node scoring functions when the solution is deemed to be so bad, it's not possible to work out *how* bad it is!
 
 The initial value is `-999999999`.
 
 #### `TIME_TO_NODE`
 
-TBD - how is this actually used?
+This is the number of seconds in the future that a mid-course correction node will be plotted.
+
+Previously, this was incremented after each correction node, so that corrections got further apart during a transfer. That functionality was removed and so this value is currently left unchanged. Future updates may reimplement the node increments or use it to specify precise times for certain nodes e.g. to apply a correction in the best position to perform an inclination change.
 
 The initial value is `900` seconds.
 
@@ -106,6 +108,7 @@ Of the input parameters, `destination` and `periapsis` must have sensible values
 If the orbit does reach the `destination`, the details of the orbit patch are compared to the input parameters. How this works:
 * The score is initialised as `MAX_SCORE`.
 * The score is reduced by the amount of delta-v (in m/s) required to burn the input `node`.
+* Points are added to the score if the estimated periapsis is close to target periapsis. These bonus points are small and vary depending on the difference (`3` for perfection, dropping to `1` at `2500`m difference, then dropping to `0` at `50000`m difference). The purpose of this is to encourage the function to find the perfect periapsis, particularly for small nodes.
 * The score is reduced by the estimated additional delta-v required to correct the periapsis after orbit insertion, assuming it is different from the target periapsis.
 * If `inclination` is not negative, the score is reduced by the estimated additional delta-v required to correct the orbit plane (`inclination` and `longitude_of_ascending_node`) following circularisation. If the input `longitude_of_ascending_node` is negative, the plane change is estimated assuming only the inclination needs correcting.
 

--- a/scripts/lib_ca.ks
+++ b/scripts/lib_ca.ks
@@ -4,7 +4,7 @@ pOut("lib_ca.ks v1.0.0 20161130").
 FUNCTION targetDist
 {
   PARAMETER t, u_time.
-  RETURN (POSITIONAT(SHIP,u_time)-POSITIONAT(t,u_time)):MAG
+  RETURN (POSITIONAT(SHIP,u_time)-POSITIONAT(t,u_time)):MAG.
 }
 
 FUNCTION targetCA

--- a/scripts/lib_ca.ks
+++ b/scripts/lib_ca.ks
@@ -1,0 +1,32 @@
+@LAZYGLOBAL OFF.
+pOut("lib_ca.ks v1.0.0 20161130").
+
+FUNCTION targetDist
+{
+  PARAMETER t, u_time.
+  RETURN (POSITIONAT(SHIP,u_time)-POSITIONAT(t,u_time)):MAG
+}
+
+FUNCTION targetCA
+{
+  PARAMETER t, u_time1, u_time2, min_step IS 1, num_slices IS 20.
+  LOCAL time_diff IS u_time2 - u_time1.
+  LOCAL step IS time_diff / num_slices.
+  IF step < min_step { RETURN ((u_time1 + u_time2) / 2). }
+
+  LOCAL ca_time IS u_time1.
+  LOCAL ca_dist IS targetDist(t,ca_time).
+
+  LOCAL temp_time IS u_time1 + step.
+  UNTIL temp_time > u_time2 {
+    LOCAL temp_dist IS targetDist(t,temp_time).
+    IF temp_dist < ca_dist {
+      SET ca_dist TO temp_dist.
+      SET ca_time TO temp_time.
+    }
+    SET temp_time TO temp_time + step.
+  }
+  SET u_time1 TO MAX(u_time1, ca_time-step).
+  SET u_time2 TO MIN(u_time2, ca_time+step).
+  RETURN targetCA(t, u_time1, u_time2, min_step, num_slices).
+}

--- a/scripts/lib_hoh.ks
+++ b/scripts/lib_hoh.ks
@@ -1,31 +1,25 @@
 @LAZYGLOBAL OFF.
-
-
-pOut("lib_hoh.ks v1.0 20160714").
+pOut("lib_hoh.ks v1.0.1 20161130").
 
 RUNONCEPATH(loadScript("lib_orbit.ks")).
 
 FUNCTION nodeHohmann
 {
-  PARAMETER t, u_time.
-  PARAMETER t_pe IS 0.
+  PARAMETER t, u_time, t_pe IS 0.
 
   LOCAL o1 IS ORBITAT(SHIP,u_time).
   LOCAL o2 IS ORBITAT(t,u_time).
   LOCAL b IS o1:BODY.
-  LOCAL mu IS b:MU.
   LOCAL r1 IS o1:SEMIMAJORAXIS.
   LOCAL r2 IS o2:SEMIMAJORAXIS + t_pe.
 
-  LOCAL dv IS SQRT(mu/r1) * (SQRT((2*r2)/(r1+r2)) -1).
+  LOCAL dv IS SQRT(b:MU/r1) * (SQRT((2*r2)/(r1+r2)) -1).
   IF r2 < r1 { SET dv TO -dv. }
 
-  LOCAL transfer_t IS CONSTANT:PI * SQRT( ((r1+r2)^3) / (8 * mu) ).
-  LOCAL desired_phi IS 180 - (360 * transfer_t / o2:PERIOD).
+  LOCAL transfer_t IS CONSTANT:PI * SQRT( ((r1+r2)^3) / (8 * b:MU) ).
+  LOCAL desired_phi IS 180 - (transfer_t * 360 / o2:PERIOD).
 
-  LOCAL angv1 IS 360 / o1:PERIOD.
-  LOCAL angv2 IS 360 / o2:PERIOD.
-  LOCAL rel_angv IS angv1 - angv2.
+  LOCAL rel_angv IS (360 / o1:PERIOD) - (360 / o2:PERIOD).
 
   LOCAL s_pos IS posAt(SHIP, u_time).
   LOCAL t_pos IS posAt(t, u_time).

--- a/scripts/lib_transfer.ks
+++ b/scripts/lib_transfer.ks
@@ -300,6 +300,14 @@ FUNCTION nodeMoonToBody
   RETURN man_node.
 }
 
+FUNCTION taEccOk
+{
+  PARAMETER orb, ta.
+  LOCAL e IS orb:ECCENTRICITY.
+  LOCAL x IS (e+COS(ta)) / (1 + (e * COS(ta))).
+  RETURN (x + SQRT(x^2 - 1)) >= 0
+}
+
 FUNCTION orbitNeedsCorrection
 {
   PARAMETER curr_orb,dest,pe,i,lan.
@@ -328,10 +336,15 @@ FUNCTION orbitNeedsCorrection
     ELSE IF VANG(orbitNormal(dest,i,lan),orbitNormal(dest,orb:INCLINATION,orb:LAN)) > 0.05 {
       LOCAL u_time IS TIME:SECONDS + 1.
       LOCAL n_ta1 IS taAN(u_time,orbitNormal(dest,i,lan)).
-      LOCAL eta1 IS secondsToTA(SHIP,u_time,n_ta1) + 1.
-      LOCAL eta2 IS secondsToTA(SHIP,u_time,mAngle(n_ta1 + 180)) + 1.
-      IF eta1 > 900 AND eta1 < (ETA:PERIAPSIS - 900) { SET TIME_TO_NODE TO eta1. RETURN TRUE. }
-      IF eta2 > 900 AND eta2 < (ETA:PERIAPSIS - 900) { SET TIME_TO_NODE TO eta2. RETURN TRUE. }
+      IF taEccOk(orb,n_ta1) { 
+        LOCAL eta1 IS secondsToTA(SHIP,u_time,n_ta1) + 1.
+        IF eta1 > 900 AND eta1 < (ETA:PERIAPSIS - 900) { SET TIME_TO_NODE TO eta1. RETURN TRUE. }
+      }
+      LOCAL n_ta2 IS mAngle(n_ta1 + 180).
+      IF taEccOk(orb, n_ta2) {
+        LOCAL eta2 IS secondsToTA(SHIP,u_time,mAngle(n_ta1 + 180)) + 1.
+        IF eta2 > 900 AND eta2 < (ETA:PERIAPSIS - 900) { SET TIME_TO_NODE TO eta2. RETURN TRUE. }
+      }
     }
   }
 

--- a/scripts/lib_transfer.ks
+++ b/scripts/lib_transfer.ks
@@ -306,7 +306,7 @@ FUNCTION taEccOk
   LOCAL e IS orb:ECCENTRICITY.
   IF e < 1 { RETURN TRUE. }
   LOCAL x IS (e+COS(ta)) / (1 + (e * COS(ta))).
-  RETURN (x + SQRT(x^2 - 1)) >= 0
+  RETURN (x + SQRT(x^2 - 1)) >= 0.
 }
 
 FUNCTION orbitNeedsCorrection

--- a/scripts/lib_transfer.ks
+++ b/scripts/lib_transfer.ks
@@ -304,6 +304,7 @@ FUNCTION taEccOk
 {
   PARAMETER orb, ta.
   LOCAL e IS orb:ECCENTRICITY.
+  IF e < 1 { RETURN TRUE. }
   LOCAL x IS (e+COS(ta)) / (1 + (e * COS(ta))).
   RETURN (x + SQRT(x^2 - 1)) >= 0
 }

--- a/scripts/lib_transfer.ks
+++ b/scripts/lib_transfer.ks
@@ -150,7 +150,7 @@ FUNCTION improveNode
   PARAMETER n, score_func.
   LOCAL ubn IS updateBest@:BIND(score_func).
 
-  LOCAL best_node IS newNodeByDiff(0,0,0,0).
+  LOCAL best_node IS newNodeByDiff(n,0,0,0,0).
   LOCAL best_score IS score_func(best_node).
   LOCAL orig_score IS best_score.
 

--- a/scripts/lib_transfer.ks
+++ b/scripts/lib_transfer.ks
@@ -137,7 +137,7 @@ FUNCTION scoreNodeDestOrbit
       IF i >= 0 {
         IF lan < 0 { SET lan TO next_lan. }
         LOCAL ang IS VANG(orbitNormal(dest,i,lan),orbitNormal(dest,next_i,next_lan)).
-        LOCAL v_circ IS SQRT(dest:MU/r).
+        LOCAL v_circ IS SQRT(dest:MU/r1).
         LOCAL dv_inc IS 2 * v_circ * SIN(ang/2).
         SET score TO score - dv_inc.
       }

--- a/scripts/lib_transfer.ks
+++ b/scripts/lib_transfer.ks
@@ -64,15 +64,16 @@ FUNCTION scoreNodeDestOrbit
   LOCAL orb_count IS orbitReachesBody(orb,dest).
   IF orb_count >= 0 {
     SET score TO MAX_SCORE - nodeDV(n).
+    LOCAL r IS dest:RADIUS + pe.
     LOCAL next_orb IS futureOrbit(orb,orb_count).
     LOCAL next_pe IS next_orb:PERIAPSIS.
     LOCAL next_i IS next_orb:INCLINATION.
     LOCAL next_lan IS next_orb:LAN.
 
     // calculate additional delta-v required to correct periapsis after circularisation
-    LOCAL a0 IS dest:RADIUS + ((next_pe + dest_pe) / 2).
-    LOCAL v0 IS SQRT(dest:MU * ((2/dest_pe)-(1/a0))).
-    LOCAL v1 IS SQRT(dest:MU/(dest:RADIUS + dest_pe)).
+    LOCAL a0 IS dest:RADIUS + ((next_pe + pe) / 2).
+    LOCAL v0 IS SQRT(dest:MU * ((2/r)-(1/a0))).
+    LOCAL v1 IS SQRT(dest:MU/r).
     LOCAL dv_pe IS ABS(v1 - v0).
     SET score TO score - dv_pe.
 
@@ -81,7 +82,7 @@ FUNCTION scoreNodeDestOrbit
     IF i >= 0 {
       IF lan < 0 { SET lan TO next_lan. }
       LOCAL ang IS VANG(orbitNormal(dest,i,lan),orbitNormal(dest,next_i,next_lan)).
-      LOCAL v_circ IS SQRT(dest:MU/(dest:RADIUS + dest_pe)).
+      LOCAL v_circ IS SQRT(dest:MU/r).
       LOCAL dv_inc IS 2 * v_circ * SIN(ang/2).
       SET score TO score - dv_inc.
     }

--- a/scripts/lib_transfer.ks
+++ b/scripts/lib_transfer.ks
@@ -142,7 +142,7 @@ FUNCTION updateBest
 FUNCTION newNodeByDiff
 {
   PARAMETER n, eta_diff, rad_diff, nrm_diff, pro_diff.
-  RETURN NODE(n:ETA+eta_diff, n:RADIALOUT+rad_diff, n:NORMAL+nrm_diff, n:PROGRADE+pro_diff).
+  RETURN NODE(TIME:SECONDS+n:ETA+eta_diff, n:RADIALOUT+rad_diff, n:NORMAL+nrm_diff, n:PROGRADE+pro_diff).
 }
 
 FUNCTION improveNode
@@ -198,7 +198,7 @@ FUNCTION nodeBodyToMoon
 {
   PARAMETER u_time, dest, dest_pe, i IS -1, lan IS -1.
 
-  LOCAL t_pe IS (dest:RADIUS + dest_pe) * COS(MIN(i,0))).
+  LOCAL t_pe IS (dest:RADIUS + dest_pe) * COS(MIN(i,0)).
 
   LOCAL hnode IS nodeHohmann(dest, u_time, t_pe).
   improveNode(hnode,scoreNodeDestOrbit@:BIND(dest,dest_pe,i,lan)).

--- a/scripts/lib_transfer.ks
+++ b/scripts/lib_transfer.ks
@@ -122,7 +122,7 @@ FUNCTION scoreNodeDestOrbit
     IF orb_count >= 0 {
       LOCAL u_time1 IS futureOrbitETATime(orb,orb_count).
       LOCAL u_time2 IS futureOrbitETATime(orb,orb_count+1).
-      SET score TO -targetDist(dest,targetCA(dest,u_time1,u_time2)) / 1000.
+      SET score TO -targetDist(dest,targetCA(dest,u_time1,u_time2,5,10)) / 1000.
     } ELSE { SET score TO MIN_SCORE. }
 
   } ELSE { SET score TO MIN_SCORE. }

--- a/scripts/lib_transfer.ks
+++ b/scripts/lib_transfer.ks
@@ -92,6 +92,11 @@ FUNCTION scoreNodeDestOrbit
     LOCAL next_i IS next_orb:INCLINATION.
     LOCAL next_lan IS next_orb:LAN.
 
+    // bonus points for being close to target periapsis
+    LOCAL pe_diff IS ABS(next_pe - pe).
+    IF pe_diff < 1000 { SET score TO score + 15. }
+    ELSE IF pe_diff < 25000 { SET score TO score + 5. }
+
     // calculate additional delta-v required to correct periapsis after circularisation
     LOCAL a0 IS dest:RADIUS + ((next_pe + pe) / 2).
     LOCAL v0 IS SQRT(dest:MU * ((2/r)-(1/a0))).


### PR DESCRIPTION
- [x] Better node scoring based on delta-v costs #89 / #91
- [x] Use a common closest approach calculator for node scoring #50
- [x] Work out when to try to change inclination #7

Move functions around/include libraries as needed e.g. pull in `lib_orbit_match.ks` to use the orbit normal / inclination calculation functions. There are also useful functions in `lib_rendezvous.ks` that could be re-written and moved to another library.

For inclination changes, we now include `lib_orbit_match.ks` so once in the sphere of influence of the destination we can calculate where/when the orbit planes cross and work out if that's within the range of the orbit where we can plot corrections. 

Testing has shown that:
* the node scoring originally implemented in this branch, that was based entirely on delta-v costs, could get stuck with very small nodes, where it wouldn't improve the predicted periapsis towards the target. To solve this, bonus points are awarded the closer to the target periapsis. The latest revision to that needs testing.
* related to the above, the "do we need a correction node?" check would often return that we did, but the node improvement function would either return a very small correction that was hard to burn accurately, or a node that did not correct the node enough (or at all). To solve this, the correction check is now a separate function, with a wider range of allowed accuracy. This needs testing.
* the original values for the closest approach calculation were rather slow. The number of slices / minimum step time have been changed to try to speed things up.

Some of the issues found in testing may be less of a problem in KSP 1.2.x. One particular example was a transfer to the Mun with a periapsis of 517km. While in Kerbin orbit, the node improvement function could not get the periapsis above about 460km. I strongly suspect this was because KSP couldn't detect the sphere of influence transition, so the 'ideal' orbit appeared to miss the target. This led to the node improvement function spending a lot more time than usual calculating close approaches, and every single burn failed to get the periapsis within the required accuracy, so new mid-course corrections were added right up until the point of the sphere of influence transition.

 - [x] To test:

The updated "is a correction node necessary?" check (now a function). This includes a variety of possibilities:
* don't make correction if too close to transition or periapsis
* the allowed periapsis variation is now different depending on the altitude of the target periapsis
* inclination changes can be made via a correction where the desired LAN isn't specified.
* inclination changes can be made if the orbit planes cross in the right place, where the desired LAN is specified. Need to see if it does anything crazy where one of the nodes is outside the range of the orbit...

The node improvement function now has bonus points. Need to try to recreate the situation where the old version wouldn't bring the periapsis closer to the desired value, though this may be harder given the other changes.

#### Further ideas and improvements:

* The closest approach check should only run if the best score we have so far is negative. If we already have a trajectory that reaches the destination, we can ignore those that miss.

* The node scoring can take into account the cost of the circularisation burn too.

* The scoring system could be modified to include large penalties for trajectories that are below the minimum altitude (or for re-entry, those that are not close to the target altitude). Altitudes to avoid could also include the altitudes occupied by moons of the destination. The bonus points needs either a big boost or possibly removing altogether - a lot of trajectories are apparently more expensive to adjust than would be saved by getting the altitude correct. As long as the trajectory is "safe", we can go with the more efficient option.

* Currently the scoring system and the "do we need a correction?" check are still in disagreement quite often. Perhaps we should simply generate a correction and if the delta-v of the burn comes out tiny, assume that we don't need a correction (yet) and proceed...

These have been implemented in the latest submission, though the "do we need a correction?" function is largely unchanged, if a correction node is generated with a delta-v smaller than 0.2m/s, it is ignored.

One thing is definitely left as a "TBD" - the only trajectories that are considered unsafe are those that drop below a minimum safe altitude. It would also be useful to consider the orbits that would potentially run into satellites of the parent body i.e. take their orbit radius and the size of their sphere of influence to produce "no entry" altitude ranges.

#### And finally...

 - [x] Turns out trying to find the mean anomaly of parts of an eccentric orbit that don't exist can cause the `secondsToTA()` function to crash (specifically, trying to call `LN()` with an input less than zero. I've added a check function, which needs testing.